### PR TITLE
Remove is-nan dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "is-nan": "^1.3.2",
     "luxon": "^1.26.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove is-nan since it is not used and one of the libs in its dependency tree is using `global` which is not working in browser. fixes #208